### PR TITLE
fix: Update Go version in workflow

### DIFF
--- a/.github/workflows/go.yml
+++ b/.github/workflows/go.yml
@@ -19,7 +19,7 @@ jobs:
     - name: Set up Go
       uses: actions/setup-go@v5
       with:
-        go-version: '1.24'
+        go-version: '1.24.1'
 
     - name: Build
       run: go build -v ./...


### PR DESCRIPTION
Updated the Go version in the GitHub Actions workflow (`.github/workflows/go.yml`) from `1.24` to `1.24.1` to match the version specified in `go.mod`.